### PR TITLE
Failing rest calls

### DIFF
--- a/CamundaApplication/src/main/java/com/example/workflow/WireMockDelegate.java
+++ b/CamundaApplication/src/main/java/com/example/workflow/WireMockDelegate.java
@@ -1,0 +1,25 @@
+package com.example.workflow;
+
+import java.net.http.HttpResponse;
+
+import javax.inject.Named;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+
+@Named
+public class WireMockDelegate extends FindGitHubRepo {
+
+  @Override
+  public void execute(DelegateExecution execution) throws Exception {
+    String wireMockUrl = (String) execution.getVariable("wireMockUrl");
+    
+    HttpResponse<String> response = get(wireMockUrl);
+
+    if (response.statusCode() != 200) {
+
+        // create incidence if Status code is not 200
+        throw new Exception("Error from REST call, Response code: " + response.statusCode());
+
+    } 
+  }
+}

--- a/CamundaApplication/src/main/resources/WireMockParallelProcess.bpmn
+++ b/CamundaApplication/src/main/resources/WireMockParallelProcess.bpmn
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0vjalzh" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="WireMockParallelProcess" name="Wiremock parallel Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Wire Mock calls wanted" camunda:formKey="embedded:/forms/wireMockStartForm.html">
+      <bpmn:outgoing>Flow_0bn5e6g</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0bn5e6g" sourceRef="StartEvent_1" targetRef="Gateway_0fwogow" />
+    <bpmn:serviceTask id="Activity_0ng6osj" name="Call via External Task" camunda:type="external" camunda:topic="wireMockCall">
+      <bpmn:incoming>Flow_00qfqbn</bpmn:incoming>
+      <bpmn:outgoing>Flow_0pyl791</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_13p05az" sourceRef="Gateway_0fwogow" targetRef="Activity_0dwqdrh" />
+    <bpmn:sequenceFlow id="Flow_0dhj5lr" sourceRef="Gateway_0fwogow" targetRef="Activity_129bhyv" />
+    <bpmn:sequenceFlow id="Flow_19eb9xn" sourceRef="Gateway_0fwogow" targetRef="Activity_071zgbu" />
+    <bpmn:endEvent id="Event_1fqwhrk" name="Rest calls completed">
+      <bpmn:incoming>Flow_0jfqzlr</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0gmun7n" sourceRef="Activity_071zgbu" targetRef="Gateway_1d9ilg4" />
+    <bpmn:serviceTask id="Activity_0dwqdrh" name="Call via JavaDelegate" camunda:asyncBefore="true" camunda:delegateExpression="${wireMockDelegate}">
+      <bpmn:incoming>Flow_13p05az</bpmn:incoming>
+      <bpmn:outgoing>Flow_1s7osws</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_071zgbu" name="Call via HTTPConnector" camunda:asyncBefore="true">
+      <bpmn:extensionElements>
+        <camunda:connector>
+          <camunda:inputOutput>
+            <camunda:inputParameter name="method">GET</camunda:inputParameter>
+            <camunda:inputParameter name="headers">
+              <camunda:map>
+                <camunda:entry key="Accept">application/json</camunda:entry>
+              </camunda:map>
+            </camunda:inputParameter>
+            <camunda:inputParameter name="url">${wireMockUrl}</camunda:inputParameter>
+            <camunda:outputParameter name="statusCode">${statusCode}</camunda:outputParameter>
+          </camunda:inputOutput>
+          <camunda:connectorId>http-connector</camunda:connectorId>
+        </camunda:connector>
+        <camunda:executionListener event="end">
+          <camunda:script scriptFormat="javascript">if(statusCode != 200){
+throw new Error("Error from REST, response Code: " + statusCode)
+}else{
+
+}</camunda:script>
+        </camunda:executionListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19eb9xn</bpmn:incoming>
+      <bpmn:outgoing>Flow_0gmun7n</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:scriptTask id="Activity_129bhyv" name="Call via Script" camunda:asyncBefore="true" scriptFormat="groovy">
+      <bpmn:incoming>Flow_0dhj5lr</bpmn:incoming>
+      <bpmn:outgoing>Flow_1b5gbvk</bpmn:outgoing>
+      <bpmn:script>import wslite.rest.RESTClient
+import wslite.rest.RESTClientException
+
+def wireMockUrl = execution.getVariable("wireMockUrl")
+
+RESTClient client = new RESTClient(wireMockUrl)
+
+try {
+    println(wireMockUrl)
+    response = client.get()
+    println(response.contentAsString)
+
+} catch (RESTClientException e) {
+    println(e)
+    throw new Exception(e)
+}</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:subProcess id="Activity_0awe1wj" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_0en2bhg">
+        <bpmn:incoming>Flow_11bfd7z</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:userTask id="Activity_1xk3o0z" name="Look at Error" camunda:assignee="#{processOwner}">
+        <bpmn:incoming>Flow_19k751n</bpmn:incoming>
+        <bpmn:outgoing>Flow_11bfd7z</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:sequenceFlow id="Flow_19k751n" sourceRef="Event_1kj3ge6" targetRef="Activity_1xk3o0z" />
+      <bpmn:sequenceFlow id="Flow_11bfd7z" sourceRef="Activity_1xk3o0z" targetRef="Event_0en2bhg" />
+      <bpmn:startEvent id="Event_1kj3ge6">
+        <bpmn:outgoing>Flow_19k751n</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_1qo0rnx" camunda:errorCodeVariable="errorCode" camunda:errorMessageVariable="errorMessage" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_00qfqbn" sourceRef="Gateway_0fwogow" targetRef="Activity_0ng6osj" />
+    <bpmn:parallelGateway id="Gateway_0fwogow">
+      <bpmn:incoming>Flow_0bn5e6g</bpmn:incoming>
+      <bpmn:outgoing>Flow_00qfqbn</bpmn:outgoing>
+      <bpmn:outgoing>Flow_13p05az</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0dhj5lr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19eb9xn</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0jfqzlr" sourceRef="Gateway_1d9ilg4" targetRef="Event_1fqwhrk" />
+    <bpmn:parallelGateway id="Gateway_1d9ilg4">
+      <bpmn:incoming>Flow_0gmun7n</bpmn:incoming>
+      <bpmn:incoming>Flow_0pyl791</bpmn:incoming>
+      <bpmn:incoming>Flow_1s7osws</bpmn:incoming>
+      <bpmn:incoming>Flow_1b5gbvk</bpmn:incoming>
+      <bpmn:outgoing>Flow_0jfqzlr</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0pyl791" sourceRef="Activity_0ng6osj" targetRef="Gateway_1d9ilg4" />
+    <bpmn:sequenceFlow id="Flow_1s7osws" sourceRef="Activity_0dwqdrh" targetRef="Gateway_1d9ilg4" />
+    <bpmn:sequenceFlow id="Flow_1b5gbvk" sourceRef="Activity_129bhyv" targetRef="Gateway_1d9ilg4" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="WireMockParallelProcess">
+      <bpmndi:BPMNEdge id="Flow_0bn5e6g_di" bpmnElement="Flow_0bn5e6g">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="245" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13p05az_di" bpmnElement="Flow_13p05az">
+        <di:waypoint x="270" y="142" />
+        <di:waypoint x="270" y="230" />
+        <di:waypoint x="340" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gmun7n_di" bpmnElement="Flow_0gmun7n">
+        <di:waypoint x="440" y="470" />
+        <di:waypoint x="510" y="470" />
+        <di:waypoint x="510" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dhj5lr_di" bpmnElement="Flow_0dhj5lr">
+        <di:waypoint x="270" y="142" />
+        <di:waypoint x="270" y="350" />
+        <di:waypoint x="340" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19eb9xn_di" bpmnElement="Flow_19eb9xn">
+        <di:waypoint x="270" y="142" />
+        <di:waypoint x="270" y="470" />
+        <di:waypoint x="340" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00qfqbn_di" bpmnElement="Flow_00qfqbn">
+        <di:waypoint x="295" y="117" />
+        <di:waypoint x="340" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jfqzlr_di" bpmnElement="Flow_0jfqzlr">
+        <di:waypoint x="535" y="117" />
+        <di:waypoint x="572" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0pyl791_di" bpmnElement="Flow_0pyl791">
+        <di:waypoint x="440" y="117" />
+        <di:waypoint x="485" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1s7osws_di" bpmnElement="Flow_1s7osws">
+        <di:waypoint x="440" y="230" />
+        <di:waypoint x="510" y="230" />
+        <di:waypoint x="510" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1b5gbvk_di" bpmnElement="Flow_1b5gbvk">
+        <di:waypoint x="440" y="350" />
+        <di:waypoint x="510" y="350" />
+        <di:waypoint x="510" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="142" width="77" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05bviel_di" bpmnElement="Activity_0ng6osj">
+        <dc:Bounds x="340" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0w66woc_di" bpmnElement="Gateway_0fwogow">
+        <dc:Bounds x="245" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1cutq6u_di" bpmnElement="Activity_129bhyv">
+        <dc:Bounds x="340" y="310" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1t77u9a_di" bpmnElement="Activity_0dwqdrh">
+        <dc:Bounds x="340" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mi84wn_di" bpmnElement="Activity_071zgbu">
+        <dc:Bounds x="340" y="430" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_01bh90n_di" bpmnElement="Gateway_1d9ilg4">
+        <dc:Bounds x="485" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1fqwhrk_di" bpmnElement="Event_1fqwhrk">
+        <dc:Bounds x="572" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="565" y="142" width="51" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0awe1wj_di" bpmnElement="Activity_0awe1wj" isExpanded="true">
+        <dc:Bounds x="290" y="540" width="310" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_11bfd7z_di" bpmnElement="Flow_11bfd7z">
+        <di:waypoint x="500" y="630" />
+        <di:waypoint x="542" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19k751n_di" bpmnElement="Flow_19k751n">
+        <di:waypoint x="346" y="630" />
+        <di:waypoint x="400" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0en2bhg_di" bpmnElement="Event_0en2bhg">
+        <dc:Bounds x="542" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xk3o0z_di" bpmnElement="Activity_1xk3o0z">
+        <dc:Bounds x="400" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1tjtlgs_di" bpmnElement="Event_1kj3ge6">
+        <dc:Bounds x="310" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/CamundaApplication/src/main/resources/WireMockProcess.bpmn
+++ b/CamundaApplication/src/main/resources/WireMockProcess.bpmn
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0vjalzh" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="WireMockProcess" name="Wiremock Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Wire Mock calls wanted" camunda:formKey="embedded:/forms/wireMockStartForm.html">
+      <bpmn:outgoing>Flow_0bn5e6g</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0bn5e6g" sourceRef="StartEvent_1" targetRef="Activity_0ng6osj" />
+    <bpmn:serviceTask id="Activity_0ng6osj" name="Call via External Task" camunda:type="external" camunda:topic="wireMockCall">
+      <bpmn:incoming>Flow_0bn5e6g</bpmn:incoming>
+      <bpmn:outgoing>Flow_13p05az</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_13p05az" sourceRef="Activity_0ng6osj" targetRef="Activity_0dwqdrh" />
+    <bpmn:sequenceFlow id="Flow_0dhj5lr" sourceRef="Activity_0dwqdrh" targetRef="Activity_129bhyv" />
+    <bpmn:sequenceFlow id="Flow_19eb9xn" sourceRef="Activity_129bhyv" targetRef="Activity_071zgbu" />
+    <bpmn:endEvent id="Event_1fqwhrk" name="Rest calls completed">
+      <bpmn:incoming>Flow_0gmun7n</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0gmun7n" sourceRef="Activity_071zgbu" targetRef="Event_1fqwhrk" />
+    <bpmn:serviceTask id="Activity_0dwqdrh" name="Call via JavaDelegate" camunda:asyncBefore="true" camunda:delegateExpression="${wireMockDelegate}">
+      <bpmn:incoming>Flow_13p05az</bpmn:incoming>
+      <bpmn:outgoing>Flow_0dhj5lr</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_071zgbu" name="Call via HTTPConnector" camunda:asyncBefore="true">
+      <bpmn:extensionElements>
+        <camunda:connector>
+          <camunda:inputOutput>
+            <camunda:inputParameter name="method">GET</camunda:inputParameter>
+            <camunda:inputParameter name="headers">
+              <camunda:map>
+                <camunda:entry key="Accept">application/json</camunda:entry>
+              </camunda:map>
+            </camunda:inputParameter>
+            <camunda:inputParameter name="url">${wireMockUrl}</camunda:inputParameter>
+            <camunda:outputParameter name="statusCode">${statusCode}</camunda:outputParameter>
+          </camunda:inputOutput>
+          <camunda:connectorId>http-connector</camunda:connectorId>
+        </camunda:connector>
+        <camunda:executionListener event="end">
+          <camunda:script scriptFormat="javascript">if(statusCode != 200){
+throw new Error("Error from REST, response Code: " + statusCode)
+}else{
+
+}</camunda:script>
+        </camunda:executionListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19eb9xn</bpmn:incoming>
+      <bpmn:outgoing>Flow_0gmun7n</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:scriptTask id="Activity_129bhyv" name="Call via Script" camunda:asyncBefore="true" scriptFormat="groovy">
+      <bpmn:incoming>Flow_0dhj5lr</bpmn:incoming>
+      <bpmn:outgoing>Flow_19eb9xn</bpmn:outgoing>
+      <bpmn:script>import wslite.rest.RESTClient
+import wslite.rest.RESTClientException
+
+def wireMockUrl = execution.getVariable("wireMockUrl")
+
+RESTClient client = new RESTClient(wireMockUrl)
+
+try {
+    println(wireMockUrl)
+    response = client.get()
+    println(response.contentAsString)
+
+} catch (RESTClientException e) {
+    println(e)
+    throw new Exception(e)
+}</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:subProcess id="Activity_0awe1wj" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_0en2bhg">
+        <bpmn:incoming>Flow_11bfd7z</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:userTask id="Activity_1xk3o0z" name="Look at Error" camunda:assignee="#{processOwner}">
+        <bpmn:incoming>Flow_19k751n</bpmn:incoming>
+        <bpmn:outgoing>Flow_11bfd7z</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:sequenceFlow id="Flow_19k751n" sourceRef="Event_1kj3ge6" targetRef="Activity_1xk3o0z" />
+      <bpmn:sequenceFlow id="Flow_11bfd7z" sourceRef="Activity_1xk3o0z" targetRef="Event_0en2bhg" />
+      <bpmn:startEvent id="Event_1kj3ge6">
+        <bpmn:outgoing>Flow_19k751n</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_1qo0rnx" camunda:errorCodeVariable="errorCode" camunda:errorMessageVariable="errorMessage" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="WireMockProcess">
+      <bpmndi:BPMNEdge id="Flow_0gmun7n_di" bpmnElement="Flow_0gmun7n">
+        <di:waypoint x="850" y="117" />
+        <di:waypoint x="912" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19eb9xn_di" bpmnElement="Flow_19eb9xn">
+        <di:waypoint x="690" y="117" />
+        <di:waypoint x="750" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dhj5lr_di" bpmnElement="Flow_0dhj5lr">
+        <di:waypoint x="530" y="117" />
+        <di:waypoint x="590" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13p05az_di" bpmnElement="Flow_13p05az">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="430" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bn5e6g_di" bpmnElement="Flow_0bn5e6g">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="142" width="77" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05bviel_di" bpmnElement="Activity_0ng6osj">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1fqwhrk_di" bpmnElement="Event_1fqwhrk">
+        <dc:Bounds x="912" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="905" y="142" width="51" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1t77u9a_di" bpmnElement="Activity_0dwqdrh">
+        <dc:Bounds x="430" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mi84wn_di" bpmnElement="Activity_071zgbu">
+        <dc:Bounds x="750" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1cutq6u_di" bpmnElement="Activity_129bhyv">
+        <dc:Bounds x="590" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0awe1wj_di" bpmnElement="Activity_0awe1wj" isExpanded="true">
+        <dc:Bounds x="250" y="210" width="310" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_11bfd7z_di" bpmnElement="Flow_11bfd7z">
+        <di:waypoint x="460" y="300" />
+        <di:waypoint x="502" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19k751n_di" bpmnElement="Flow_19k751n">
+        <di:waypoint x="306" y="300" />
+        <di:waypoint x="360" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0en2bhg_di" bpmnElement="Event_0en2bhg">
+        <dc:Bounds x="502" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xk3o0z_di" bpmnElement="Activity_1xk3o0z">
+        <dc:Bounds x="360" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1tjtlgs_di" bpmnElement="Event_1kj3ge6">
+        <dc:Bounds x="270" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/CamundaApplication/src/main/resources/application.yaml
+++ b/CamundaApplication/src/main/resources/application.yaml
@@ -10,4 +10,12 @@ logging:
     '[org.apache.http.headers]': DEBUG
     '[org.apache.http.wire]': DEBUG
     '[connectjar.org.apache.http.headers]': DEBUG
-    '[connectjar.org.apache.http.wire]': DEBUG 
+    '[connectjar.org.apache.http.wire]': DEBUG
+    
+camunda:
+  bpm:
+    generic-properties:
+      properties:
+        deployChangedOnly: true
+
+    default-number-of-retries: 1

--- a/CamundaApplication/src/main/resources/static/forms/wireMockStartForm.html
+++ b/CamundaApplication/src/main/resources/static/forms/wireMockStartForm.html
@@ -1,0 +1,30 @@
+<form class="form-horizontal">
+  <div class="form-group">
+    <label class="control-label col-md-4">Mocked Url</label>
+    <div class="col-md-8">
+      <select
+             cam-variable-name="wireMockUrl"
+             cam-variable-type="String"
+             required
+             class="form-control">
+        <option value="http://localhost:8089/some/thing">ok</option>
+        <option value="http://localhost:8089/delay">delay</option>
+        <option value="http://localhost:8089/does/not/exist">404</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label class="control-label col-md-4">Key</label>
+    <div class="col-md-8">
+      <input type="text"
+             cam-business-key=""
+             required
+             class="form-control" />
+    </div>
+  </div>
+
+  <script cam-script type="text/form-script">
+    // custom JavaScript goes here
+  </script>
+</form>

--- a/CamundaApplication/src/main/resources/static/forms/wireMockStartForm.html
+++ b/CamundaApplication/src/main/resources/static/forms/wireMockStartForm.html
@@ -10,6 +10,7 @@
         <option value="http://localhost:8089/some/thing">ok</option>
         <option value="http://localhost:8089/delay">delay</option>
         <option value="http://localhost:8089/does/not/exist">404</option>
+        <option value="http://localhost:8089/server/breakdown">breakdown</option>
       </select>
     </div>
   </div>

--- a/CamundaApplication/src/main/resources/static/forms/wireMockStartForm.html
+++ b/CamundaApplication/src/main/resources/static/forms/wireMockStartForm.html
@@ -9,6 +9,7 @@
              class="form-control">
         <option value="http://localhost:8089/some/thing">ok</option>
         <option value="http://localhost:8089/delay">delay</option>
+        <option value="http://localhost:8089/long/delay">long delay</option>
         <option value="http://localhost:8089/does/not/exist">404</option>
         <option value="http://localhost:8089/server/breakdown">breakdown</option>
       </select>

--- a/WireMockServer/java/pom.xml
+++ b/WireMockServer/java/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.camunda.devrel</groupId>
+  <artifactId>wiremock-server</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <version>2.30.0</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+    
+  </dependencies>
+</project>

--- a/WireMockServer/java/src/main/java/org/camunda/devrel/WiremockServer.java
+++ b/WireMockServer/java/src/main/java/org/camunda/devrel/WiremockServer.java
@@ -1,0 +1,26 @@
+package org.camunda.devrel;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+public class WiremockServer {
+
+  public static void main(String[] args) {
+    WireMockServer wireMockServer = new WireMockServer(options().port(8089));
+    wireMockServer.start();
+    
+    wireMockServer.stubFor(get(urlEqualTo("/some/thing"))
+        .willReturn(okJson("{ \"message\": \"Hello\" }")));
+    
+    wireMockServer.stubFor(get(urlEqualTo("/delay"))
+        .willReturn(aResponse()
+            .withFixedDelay(10000)
+            .withHeader("Content-Type", "application/json")
+            .withBody("{ \"message\": \"this is 10 seconds late\" }")));
+    
+    wireMockServer.stubFor(get(urlEqualTo("/does/not/exist")).willReturn(notFound()));
+  }
+
+}

--- a/WireMockServer/java/src/main/java/org/camunda/devrel/WiremockServer.java
+++ b/WireMockServer/java/src/main/java/org/camunda/devrel/WiremockServer.java
@@ -21,6 +21,12 @@ public class WiremockServer {
             .withHeader("Content-Type", "application/json")
             .withBody("{ \"message\": \"this is 10 seconds late\" }")));
     
+    wireMockServer.stubFor(get(urlEqualTo("/long/delay"))
+        .willReturn(aResponse()
+            .withFixedDelay(600000)
+            .withHeader("Content-Type", "application/json")
+            .withBody("{ \"message\": \"You have been patient. This was 10 Minute delay\" }")));
+    
     wireMockServer.stubFor(get(urlEqualTo("/does/not/exist")).willReturn(notFound()));
     
     wireMockServer.stubFor(get(urlEqualTo("/server/breakdown"))

--- a/WireMockServer/java/src/main/java/org/camunda/devrel/WiremockServer.java
+++ b/WireMockServer/java/src/main/java/org/camunda/devrel/WiremockServer.java
@@ -4,6 +4,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.Fault;
 
 public class WiremockServer {
 
@@ -21,6 +22,11 @@ public class WiremockServer {
             .withBody("{ \"message\": \"this is 10 seconds late\" }")));
     
     wireMockServer.stubFor(get(urlEqualTo("/does/not/exist")).willReturn(notFound()));
+    
+    wireMockServer.stubFor(get(urlEqualTo("/server/breakdown"))
+        .willReturn(aResponse()
+            .withFixedDelay(2000)
+            .withFault(Fault.CONNECTION_RESET_BY_PEER)));
   }
 
 }

--- a/WireMockServer/java/src/main/resources/logback.xml
+++ b/WireMockServer/java/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="org.apache.ibatis" level="info" />
+  <logger name="javax.activation" level="info" />
+  <logger name="org.springframework" level="info" />
+
+  <logger name="org.eclipse.jetty" level="info" />
+ </configuration>


### PR DESCRIPTION
## Introduce two new processes to test the different service task implemenation against a failing REST server.

The Folder WireMockService contains a java class that starts a wire mock server on port 8089 with some endpoints for:
* successful response
* delayed reponse for the impaitent (10 seconds) 
* very long delay (10 minutes)
* resource not found (404)
* Server breakdown after 2 seconds

The first process (WireMockProcess) contains 4 service tasks in a row to test each type.

The second process (WireMockParallelProcess) contains 4 service tasks after a parallel gateway.

Java Delegate and External Task have special implementations to get the URL from a process variable.

In the start form you can choose, which of the 5 WireMock urls to call. All services calls the same url.

Then you can inspect in Cockpit what happens. If everything is OK, nothing to see. For server breakdown, you will see four incidents in the Parallel process.